### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you have any questions, feel free to send me E-mails: mail@yli.one. If you fi
 > 
 > Li, Y., Kind, T., Folz, J. _et al._ **Spectral entropy outperforms MS/MS dot product similarity for small-molecule compound identification**, _Nat Methods_ **18**, 1524-1531 (2021). [https://doi.org/10.1038/s41592-021-01331-z](https://doi.org/10.1038/s41592-021-01331-z)
 
-# Theoritical Background
+# Theoretical Background
 
 `Spectral entropy` is an useful property to measure the complexity of a spectrum. It is inspried by the concept of Shannon entropy in information theory. [(ref)](https://doi.org/10.1038/s41592-021-01331-z)
 
@@ -116,7 +116,7 @@ entropy_similarity <- calculate_entropy_similarity(peaks_a, peaks_b, ms2_toleran
     float noise_threshold = 0.01;
     int max_peak_num = -1;
 
-    // Alway clean the spectrum before calculating spectral entropy
+    // Always clean the spectrum before calculating spectral entropy
     spec_a_len = clean_spectrum(*spec_a, spec_a_len, min_mz, max_mz, noise_threshold, max_peak_num, ms2_tolerance_in_da, ms2_tolerance_in_ppm, max_peak_num, normalize_intensity);
 
     // Calculate spectral entropy

--- a/docs/source/entropy_search_advanced_usage.rst
+++ b/docs/source/entropy_search_advanced_usage.rst
@@ -12,7 +12,7 @@ To achieve this, while constructing the ``FlashEntropySearch`` object, you need 
 
 The ``low_memory`` parameter has three values:
     - False or 0: Normal mode. All the index will be loaded into memory, this is the default mode and the fastest mode.
-    - True or 1: Low memory mode. Only load the nessessary data into memory, this mode needs the lowest memory, but the search speed will be the slowest, as it will read all the data from the disk every time.
+    - True or 1: Low memory mode. Only load the necessary data into memory, this mode needs the lowest memory, but the search speed will be the slowest, as it will read all the data from the disk every time.
     - 2: Low memory mode use memmap. This mode is similar to mode 1, but it will use the ``numpy.memmap`` to map the index file to memory, which will be faster than mode 1 if the memory is not too small.
 
 .. code-block:: python

--- a/docs/source/entropy_search_basic_usage.rst
+++ b/docs/source/entropy_search_basic_usage.rst
@@ -56,7 +56,7 @@ The initial step in using the Flash Entropy Search algorithm involves building a
 
 
 .. note::
-    If you want to calcualte unweighted entropy similarity instead of weighted entropy similarity, you can set the ``intensity_weight`` parameter to ``None`` when constructing the ``FlashEntropySearch`` object. For example:
+    If you want to calculate unweighted entropy similarity instead of weighted entropy similarity, you can set the ``intensity_weight`` parameter to ``None`` when constructing the ``FlashEntropySearch`` object. For example:
 
     .. code-block:: python
 

--- a/docs/source/entropy_search_examples.rst
+++ b/docs/source/entropy_search_examples.rst
@@ -135,4 +135,4 @@ Upon successful index construction, a second run of ``example-search_mona-with_r
 example-search_mona-with_pickle_functions.py
 ============================================
 
-An other example shows how to use the Flash entropy search to search the [MassBank.us (MoNA)](https://massbank.us/) database. This example use build-in pickle functions to save and load index.
+An other example shows how to use the Flash entropy search to search the [MassBank.us (MoNA)](https://massbank.us/) database. This example use built-in pickle functions to save and load index.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -68,7 +68,7 @@ To operate in Cython mode, compile the Cython code after cloning the repository:
   - On Windows, you will need to install the `Microsoft Visual C++ 14.0 or greater Build Tools <https://visualstudio.microsoft.com/visual-cpp-build-tools/>`_ first.
   - On macOS, you will need to install the ``Xcode Command Line Tools`` first.
 
-- Downlaod and compile
+- Download and compile
 
   .. code-block:: bash
 


### PR DESCRIPTION
This PR fixes typos found by running [`codespell`](https://github.com/codespell-project/codespell) on the codebase.